### PR TITLE
Fixed callback signature in file.read for keymap.json

### DIFF
--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ define(function(require, exports, module) {
 						files = files.map(function(file) {
 							if (path.basename(file.fullPath) == 'keymap.json') {
 								waitForKeymap = true;
-								file.read({encoding: 'utf8'}, function(content) {
+								file.read({encoding: 'utf8'}, function(err, content) {
 									keymap = content;
 									complete();
 								});


### PR DESCRIPTION
The previous signature used just callback, taking the 'null' value for err and assigning it to keymap, throwing a null-value error when the keymap variable was accessed later on.
