### PR TITLE
Convert Windows path to Unix path

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ define(function(require, exports, module) {
 	var EditorManager     = brackets.getModule('editor/EditorManager');
 	var Dialogs           = brackets.getModule('widgets/Dialogs');
 	var FileSystem        = brackets.getModule('filesystem/FileSystem');
+	var FileUtils         = brackets.getModule('file/FileUtils');
 	var ExtensionUtils    = brackets.getModule('utils/ExtensionUtils');
 	var AppInit           = brackets.getModule('utils/AppInit');
 
@@ -120,6 +121,7 @@ define(function(require, exports, module) {
 
 	function loadExtensions(callback) {
 		var extPath = preferences.getPreference('extPath');
+		extPath = FileUtils.convertWindowsPathToUnixPath(extPath);
 		if (extPath) {
 			var dir;
 			try {


### PR DESCRIPTION
Custom snippets doesn't work on Windows because the function  `FileSystem.getDirectoryForPath` expects a Unix path, not a Windows one.

This problem prevents the extension to load external files on Windows. To solve it, we can use the function `FileUtils.convertWindowsPathToUnixPath` provided by Brackets itself.