### PR TITLE
Fix Enter key event for interactive Expand Abbr.

### DIFF
--- a/prompt.js
+++ b/prompt.js
@@ -51,6 +51,8 @@ define(function(require, exports, module) {
 	AppInit.appReady(function() {
 		panel = WorkspaceManager.createBottomPanel('io.emmet.interactive-prompt', $panel);
 
+        var isKeyEnterDown = false;
+
 		// register keyboard handlers
 		$panel.find('.emmet-prompt__input')
 			.on('keyup', function(evt) {
@@ -61,8 +63,10 @@ define(function(require, exports, module) {
 				}
 
 				if (evt.keyCode === KeyEvent.DOM_VK_RETURN || evt.keyCode === KeyEvent.DOM_VK_ENTER) {
-					$panel.triggerHandler('confirm.emmet', [this.value]);
-					hidePanel();
+					if (isKeyEnterDown) {
+                        $panel.triggerHandler('confirm.emmet', [this.value]);
+                        hidePanel();
+                    }
 					return evt.preventDefault();
 				}
 
@@ -72,6 +76,11 @@ define(function(require, exports, module) {
 					return evt.preventDefault();
 				}
 			})
+            .on('keydown', function(evt) {
+                if (evt.keyCode === KeyEvent.DOM_VK_RETURN || evt.keyCode === KeyEvent.DOM_VK_ENTER) {
+					isKeyEnterDown = true;
+				}
+            })
 			.on('blur cancel', function() {
 				setTimeout(function() {
 					if (panel.isVisible()) {

--- a/prompt.js
+++ b/prompt.js
@@ -14,9 +14,12 @@ define(function(require, exports, module) {
 	var $panel = $(panelHtml);
 	var panel = null;
 
+    var isKeyEnterDown = false;
+
 	function hidePanel() {
 		$panel.off('.emmet');
 		panel.hide();
+        isKeyEnterDown = false;
 	}
 
 	function noop() {}
@@ -50,8 +53,6 @@ define(function(require, exports, module) {
 
 	AppInit.appReady(function() {
 		panel = WorkspaceManager.createBottomPanel('io.emmet.interactive-prompt', $panel);
-
-        var isKeyEnterDown = false;
 
 		// register keyboard handlers
 		$panel.find('.emmet-prompt__input')


### PR DESCRIPTION
Because Emmet's Interactive Expand Abbreviations panel shows up when the `Ctrl + Shift + Alt + Enter` (default value) key are pressed (down), when the `Enter` key is up, the panel suddenly closed. So there is no time for typing anything into.

This is a hack for preventing the panel from being closed.